### PR TITLE
Remove side effects from import of denoflate

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -7,23 +7,22 @@ export {
   unzlib,
 } from "./pkg/denoflate.js";
 
-import init from "./pkg/denoflate.js";
+import init as wasm from "./pkg/denoflate.js";
+
+export let initialized = false;
 
 async function read(path: string) {
   const url = new URL(path, import.meta.url);
 
-  if (url.protocol === "file:") {
+  if (url.protocol === "file:")
     return await Deno.readFile(url);
-  }
 
   const res = await fetch(url)
   return await res.arrayBuffer();
 }
 
-let wasmInitialised;
-export async function initWasm() {
-  if (!wasmInitialised) {
-    await init(read("./pkg/denoflate_bg.wasm"));
-    wasmInitialised = true;
-  }
+export async function init() {
+  if (initialized) return;
+  await wasm(read("./pkg/denoflate_bg.wasm"));
+  initialised = true;
 }

--- a/mod.ts
+++ b/mod.ts
@@ -7,7 +7,7 @@ export {
   unzlib,
 } from "./pkg/denoflate.js";
 
-import init as wasm from "./pkg/denoflate.js";
+import wasm from "./pkg/denoflate.js";
 
 export let initialized = false;
 
@@ -24,5 +24,5 @@ async function read(path: string) {
 export async function init() {
   if (initialized) return;
   await wasm(read("./pkg/denoflate_bg.wasm"));
-  initialised = true;
+  initialized = true;
 }

--- a/mod.ts
+++ b/mod.ts
@@ -20,4 +20,10 @@ async function read(path: string) {
   return await res.arrayBuffer();
 }
 
-await init(read("./pkg/denoflate_bg.wasm"));
+let wasmInitialised;
+export async function initWasm() {
+  if (!wasmInitialised) {
+    await init(read("./pkg/denoflate_bg.wasm"));
+    wasmInitialised = true;
+  }
+}

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,5 @@
 import {
-  initWasm,
+  init,
   inflate,
   deflate,
   gzip,
@@ -8,7 +8,7 @@ import {
   unzlib,
 } from "./mod.ts";
 
-await initWasm();
+await init();
 
 const bytes = new Uint8Array([1, 2, 3]);
 console.log(bytes);

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,5 @@
 import {
+  initWasm,
   inflate,
   deflate,
   gzip,
@@ -6,6 +7,8 @@ import {
   zlib,
   unzlib,
 } from "./mod.ts";
+
+await initWasm();
 
 const bytes = new Uint8Array([1, 2, 3]);
 console.log(bytes);


### PR DESCRIPTION
This stops the import of "https://deno.land/x/denoflate/mod.ts" having the side effect of downloading
https://deno.land/x/denoflate@1.1/pkg/denoflate_bg.wasm because ideally imports do not have any side effects, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import

This is a breaking change for users of the module who will have to explicitly call `initWasm()` before making use of any of the available functions.

Making this change enables users of the module to decide if/when to run this initialisation.

An alternative approach to this would be to set all of the exported methods  `deflate`, `inflate`, `gzip`, `gunzip`, `zlib`, and `unzlib` to be `async` and modify them to initialise the WASM when calling them for the first time. This would result in a different breaking change for users of this module.